### PR TITLE
force utf8 for the install description read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ giddy a try if you are interested in space-time analysis!
 
 DOCLINES = __doc__.split("\n")
 
-with open('README.rst') as file:
+with open('README.rst', 'r', encoding='utf8') as file:
     long_description = file.read()
 
 


### PR DESCRIPTION
If you install on a computer with a non-utf locale (e.g. where everything is assumed to be POSIX/ASCII), the install fails, since our `README.rst` has a non-posix character. 

This fixes any read problems that arise in this fashion by forcing the read to be UTF8, regardless of system locale. 