### PR TITLE
replace `libpysal.api` imports with new imports in `markov.py` and `d…

### DIFF
--- a/giddy/directional.py
+++ b/giddy/directional.py
@@ -10,7 +10,7 @@ __all__ = ['Rose']
 import warnings
 
 import numpy as np
-from libpysal.api import lag_spatial
+from libpysal.weights.spatial_lag import lag_spatial
 
 _POS8 = np.array([1, 1, 0, 0, 1, 1, 0, 0])
 _POS4 = np.array([1, 0, 1, 0])

--- a/giddy/markov.py
+++ b/giddy/markov.py
@@ -12,7 +12,8 @@ from .ergodic import steady_state as STEADY_STATE
 from .components import Graph
 from scipy import stats
 from operator import gt
-import libpysal.api as ps
+from libpysal.weights.spatial_lag import lag_spatial
+from libpysal.weights.spatial_lag import lag_categorical
 from esda.moran import Moran_Local
 import mapclassify.api as mc
 import itertools
@@ -738,10 +739,10 @@ class Spatial_Markov(object):
         '''
         if self.discrete:
             #np.random.seed(24788)
-            self.lclass_ids = ps.lag_categorical(w, self.class_ids,
+            self.lclass_ids = lag_categorical(w, self.class_ids,
                                                  ties="tryself")
         else:
-            ly = ps.lag_spatial(w, y)
+            ly = lag_spatial(w, y)
             self.lclass_ids, self.lag_cutoffs,self.m = self._maybe_classify(
                 ly, self.m, self.lag_cutoffs)
             self.lclasses = np.arange(self.m)
@@ -1194,7 +1195,7 @@ class LISA_Markov(Markov):
 
         ybar = y.mean(axis=0)
         r = y / ybar
-        ylag = np.array([ps.lag_spatial(w, yt) for yt in y])
+        ylag = np.array([lag_spatial(w, yt) for yt in y])
         rlag = ylag / ybar
         rc = r < 1.
         rlagc = rlag < 1.

--- a/giddy/markov.py
+++ b/giddy/markov.py
@@ -15,7 +15,7 @@ from operator import gt
 from libpysal.weights.spatial_lag import lag_spatial
 from libpysal.weights.spatial_lag import lag_categorical
 from esda.moran import Moran_Local
-import mapclassify.api as mc
+import mapclassify as mc
 import itertools
 
 # TT predefine LISA transitions
@@ -93,7 +93,7 @@ class Markov(object):
     US nominal per capita income 48 states 81 years 1929-2009
 
     >>> import libpysal
-    >>> import mapclassify.api as mc
+    >>> import mapclassify as mc
     >>> f = libpysal.open(libpysal.examples.get_path("usjoin.csv"))
     >>> pci = np.array([f.by_col[str(y)] for y in range(1929,2010)])
 
@@ -551,7 +551,7 @@ class Spatial_Markov(object):
     Let's still use the US state income time series to demonstrate. We first
     discretize them into categories and then pass them to Spatial_Markov.
 
-    >>> import mapclassify.api as mc
+    >>> import mapclassify as mc
     >>> y = mc.Quantiles(rpci.flatten(), k=5).yb.reshape(rpci.shape)
     >>> np.random.seed(5)
     >>> sm = Spatial_Markov(y, w, discrete=True, variable_name='discretized rpci')


### PR DESCRIPTION
In `markov.py` and `directional.py` replace `from libpysal.api import lag_spatial` and `lag_categorical` with:

`from libpysal.weights.spatial_lag import lag_spatial` or respectively,
`from libpysal.weights.spatial_lag import lag_categorical`

and

`import mapclassify.api` to
`import mapclassify` where needed in `markov.py`

This pull_request is needed for https://github.com/pysal/splot/pull/27 