### PR TITLE
update required versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 scipy>=0.11
-pandas
-libpysal
-mapclassify
-esda
+libpysal>=4.0.0
+mapclassify>=2.0.0
+esda>=2.0.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -4,3 +4,4 @@ nose-exclude
 coverage
 coveralls
 matplotlib
+pandas


### PR DESCRIPTION
Update the required versions of pysal submodule dependencies - `libpysal>=4.0.0`, `esda>=2.0.0` and `mapclassify>=2.0.0` since the current `giddy` only works on those versions which underwent substantial API changes.