### PR TITLE
fix missing reference labels in rendered docs 

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -71,3 +71,8 @@
 /* Table with a scrollbar */
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
+
+.label {
+    color: #222222;
+    font-size: 100%;
+}

--- a/doc/_static/references.bib
+++ b/doc/_static/references.bib
@@ -1,12 +1,30 @@
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% https://bibdesk.sourceforge.io/
 
-%% Created for Wei Kang at 2018-09-10 17:38:34 -0700 
+%% Created for weikang at 2018-12-24 21:06:10 -0800 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@article{Kang2018,
+	Abstract = {Spatial effects have been recognized to play an important role in transitional dynamics of regional incomes. Detection and evaluation of both spatial heterogeneity and spatial dependence in discrete Markov chain models, which have been widely applied to the study of regional income distribution dynamics and convergence, are vital, but under-explored issues. Indeed, in this spatiotemporal setting, spatial effects can take much more complex forms than that in a pure cross-sectional setting. In this paper, we address two test frameworks. The first is a conditional spatial Markov chains test framework, which can be used to detect spatial heterogeneity and temporally lagged spatial dependence; the second is a joint spatial Markov chains test framework, which tests for contemporaneous spatial dependence. A series of Monte Carlo experiments are designed to examine size, power and robustness properties of these tests for a range of sample sizes (spatial {\$}{\$}{\backslash}times {\$}{\$}{\texttimes}temporal dimensions), for different levels of discretization granularity and for different number of regimes. Results indicate that all tests display good size property except when sample size is fairly small. All tests for spatial dependence are similar in almost all aspects---size, power and robustness. Conditional spatial Markov tests for spatial heterogeneity have highest power for detecting spatial heterogeneity. Granularity of discretization has a major impact on the size properties of the tests when sample size is fairly small.},
+	Author = {Kang, Wei and Rey, Sergio J.},
+	Date-Added = {2018-12-24 21:05:56 -0800},
+	Date-Modified = {2018-12-24 21:05:56 -0800},
+	Day = {01},
+	Doi = {10.1007/s00168-017-0859-9},
+	Issn = {1432-0592},
+	Journal = {The Annals of Regional Science},
+	Month = {Jul},
+	Number = {1},
+	Pages = {73--93},
+	Title = {Conditional and joint tests for spatial effects in discrete Markov chain models of regional income distribution dynamics},
+	Url = {https://doi.org/10.1007/s00168-017-0859-9},
+	Volume = {61},
+	Year = {2018},
+	Bdsk-Url-1 = {https://doi.org/10.1007/s00168-017-0859-9}}
 
 @book{Ibe2009,
 	Address = {Amsterdam},
@@ -78,21 +96,6 @@
 	Volume = {18},
 	Year = {2016},
 	Bdsk-Url-1 = {http://dx.doi.org/10.1007/s10109-016-0234-x}}
-
-@article{Kang2018,
-	Abstract = {Spatial effects have been recognized to play an important role in transitional dynamics of regional incomes. Detection and evaluation of both spatial heterogeneity and spatial dependence in discrete Markov chain models, which have been widely applied to the study of regional income distribution dynamics and convergence, are vital, but under-explored issues. Indeed, in this spatiotemporal setting, spatial effects can take much more complex forms than that in a pure cross-sectional setting. In this paper, we address two test frameworks. The first is a conditional spatial Markov chains test framework, which can be used to detect spatial heterogeneity and temporally lagged spatial dependence; the second is a joint spatial Markov chains test framework, which tests for contemporaneous spatial dependence. A series of Monte Carlo experiments are designed to examine size, power and robustness properties of these tests for a range of sample sizes (spatial                                                                   {\$}{\$}{\backslash}times {\$}{\$}                                                      {\texttimes}                                                 temporal dimensions), for different levels of discretization granularity and for different number of regimes. Results indicate that all tests display good size property except when sample size is fairly small. All tests for spatial dependence are similar in almost all aspects---size, power and robustness. Conditional spatial Markov tests for spatial heterogeneity have highest power for detecting spatial heterogeneity. Granularity of discretization has a major impact on the size properties of the tests when sample size is fairly small.},
-	Author = {Kang, Wei and Rey, Sergio J.},
-	Date-Added = {2018-06-20 17:09:37 +0000},
-	Date-Modified = {2018-06-20 17:09:37 +0000},
-	Day = {06},
-	Doi = {10.1007/s00168-017-0859-9},
-	Issn = {1432-0592},
-	Journal = {The Annals of Regional Science},
-	Month = {Jan},
-	Title = {Conditional and joint tests for spatial effects in discrete {Markov} chain models of regional income distribution dynamics},
-	Url = {https://doi.org/10.1007/s00168-017-0859-9},
-	Year = {2018},
-	Bdsk-Url-1 = {https://doi.org/10.1007/s00168-017-0859-9}}
 
 @article{Rey2016,
 	Abstract = { In the study of income inequality dynamics, the concept of exchange mobility plays a central role. Applications of classical rank correlation statistics have been used to assess the degree to which individual economies swap positions in the income distribution over time. These classic measures ignore the underlying geographical pattern of rank changes. Rey (2004) introduced a spatial concordance statistic as an extension of Kendall's rank correlation statistic, a commonly employed measure of exchange mobility. This article suggests local forms of the global spatial concordance statistic: local indicators of mobility association (LIMA). The LIMA statistics allow for the decomposition of the global measure into the contributions associated with individual locations. They do so by considering the degree of concordance (stability) or discordance (exchange mobility) reflected within an economy's local spatial context. Different forms of the LIMAs derive from alternative expressions of the neighborhood and neighbor set. Additionally, the additive decomposition of the LIMAs permits the development of a mesolevel analytic to examine whether the overall space--time concordance is driven by either interregional or intraregional concordance. The measures are illustrated in a case study that examines regional income dynamics in Mexico. },
@@ -210,7 +213,7 @@
 	Publisher = {Van Nostrand},
 	Title = {Finite markov chains},
 	Year = {1967},
-	Bdsk-File-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QNi4uLy4uLy4uLy4uLy4uLy4uL0Ryb3Bib3ggKEFTVSkvcGFwZXJzL0tlbWVueS8xOTY3LnBkZtIXCxgZV05TLmRhdGFPEQFSAAAAAAFSAAIAAAxNYWNpbnRvc2ggSEQAAAAAAAAAAAAAAAAAAAAAAAAAQkQAAf////8IMTk2Ny5wZGYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/////wAAAAAAAAAAAAAAAAAGAAQAAAogY3UAAAAAAAAAAAAAAAAABktlbWVueQACADQvOlVzZXJzOndlaWthbmc6RHJvcGJveCAoQVNVKTpwYXBlcnM6S2VtZW55OjE5NjcucGRmAA4AEgAIADEAOQA2ADcALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASADJVc2Vycy93ZWlrYW5nL0Ryb3Bib3ggKEFTVSkvcGFwZXJzL0tlbWVueS8xOTY3LnBkZgATAAEvAAAVAAIADv//AACABtIbHB0eWiRjbGFzc25hbWVYJGNsYXNzZXNdTlNNdXRhYmxlRGF0YaMdHyBWTlNEYXRhWE5TT2JqZWN00hscIiNcTlNEaWN0aW9uYXJ5oiIgXxAPTlNLZXllZEFyY2hpdmVy0SYnVHJvb3SAAQAIABEAGgAjAC0AMgA3AEAARgBNAFUAYABnAGoAbABuAHEAcwB1AHcAhACOAMcAzADUAioCLAIxAjwCRQJTAlcCXgJnAmwCeQJ8Ao4CkQKWAAAAAAAAAgEAAAAAAAAAKAAAAAAAAAAAAAAAAAAAApg=}}
+	Bdsk-File-1 = {YnBsaXN0MDDSAQIDBFxyZWxhdGl2ZVBhdGhZYWxpYXNEYXRhXxA2Li4vLi4vLi4vLi4vLi4vLi4vRHJvcGJveCAoQVNVKS9wYXBlcnMvS2VtZW55LzE5NjcucGRmTxEBUgAAAAABUgACAAAMTWFjaW50b3NoIEhEAAAAAAAAAAAAAAAAAAAAAAAAAEJEAAH/////CDE5NjcucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////8AAAAAAAAAAAAAAAAABgAEAAAKIGN1AAAAAAAAAAAAAAAAAAZLZW1lbnkAAgA0LzpVc2Vyczp3ZWlrYW5nOkRyb3Bib3ggKEFTVSk6cGFwZXJzOktlbWVueToxOTY3LnBkZgAOABIACAAxADkANgA3AC4AcABkAGYADwAaAAwATQBhAGMAaQBuAHQAbwBzAGgAIABIAEQAEgAyVXNlcnMvd2Vpa2FuZy9Ecm9wYm94IChBU1UpL3BhcGVycy9LZW1lbnkvMTk2Ny5wZGYAEwABLwAAFQACAA7//wAAAAgADQAaACQAXQAAAAAAAAIBAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAGz}}
 
 @article{Rey2001,
 	Author = {Rey, Sergio J.},


### PR DESCRIPTION
This PR is to adjust CSS to display the "missing" reference labels in rendered docs 

related to #77 