### PR TITLE
Prepare for release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,54 @@
-Version 2.0.0 (2018-08-26)
+# Version 2.1.0 (2019-04-08)
+
+We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.
+
+## Issues Closed
+  - Add splot as a soft dependency for giddy  (#84)
+  - .travis built on archaic Miniconda (#82)
+  - explicitly specifying Miniconda3 in .travis.yml (#83)
+  - configure doctest and coverage testing (#81)
+  - remove plot directive and indents (#80)
+  - reference labels are missing from rendered docs (#77)
+  - fix missing reference labels in rendered docs  (#79)
+  - (ENH) Full rank and geographic rank Markov methods (#73)
+  - (BUG) update directional notebook to accommodate changes in libpysal (#78)
+  - (BUG) fix notebooks (#76)
+  - remove redundant installation in travis.yml (#75)
+  - add pypi badge to README (#74)
+  - (BUG) remove libpysal.api in Rank notebook (#72)
+  - update required versions of dependencies (#71)
+  - Update issue templates (#70)
+  - conform to PEP8 style guide (#69)
+  - Singular matrix when computing ergodic values (#32)
+  - build notebooks for documentation (#6)
+  - update README with new doi and doc website (#68)
+  - REL: 2.0.0 (#67)
+
+## Pull Requests
+  - Add splot as a soft dependency for giddy  (#84)
+  - explicitly specifying Miniconda3 in .travis.yml (#83)
+  - configure doctest and coverage testing (#81)
+  - remove plot directive and indents (#80)
+  - fix missing reference labels in rendered docs  (#79)
+  - (ENH) Full rank and geographic rank Markov methods (#73)
+  - (BUG) update directional notebook to accommodate changes in libpysal (#78)
+  - (BUG) fix notebooks (#76)
+  - remove redundant installation in travis.yml (#75)
+  - add pypi badge to README (#74)
+  - (BUG) remove libpysal.api in Rank notebook (#72)
+  - update required versions of dependencies (#71)
+  - Update issue templates (#70)
+  - conform to PEP8 style guide (#69)
+  - update README with new doi and doc website (#68)
+  - REL: 2.0.0 (#67)
+
+The following individuals contributed to this release:
+
+  - Wei Kang
+  - James Gaboardi
+  - Serge Rey
+  
+# Version 2.0.0 (2018-08-26)
 
 This release does not add any new functionality to `giddy`, but
 instead features api changes in `giddy` and its
@@ -40,7 +90,7 @@ The following individuals contributed to this release:
   - Wei Kang
   - Stefanie Lumnitz
 
-v<1.2.0>, 2018-07-27
+# Version 1.2.0 (2018-07-27)
 
 This release features:
 * a more flexible specification for the [spatial Markov chains model](https://github.com/pysal/giddy/blob/master/giddy/markov.py#L169).More specifically, for continuous time series input:
@@ -59,7 +109,7 @@ We closed a total of 34 issues, 16 pull requests and 18 regular issues;
 this is the full list (generated with the script
 :file:`tools/github_stats.py`):
 
-Pull Requests (16):
+## Pull Requests (16):
 
 * :ghpull:`56`: b'prepare for release 1.2.0'
 * :ghpull:`55`: b'set up dual travis tests for libpysal (pip and github)'
@@ -78,7 +128,7 @@ Pull Requests (16):
 * :ghpull:`40`: b'typo - email notifications'
 * :ghpull:`38`: b'fix for python 3'
 
-Issues (18):
+## Issues (18):
 
 * :ghissue:`56`: b'prepare for release 1.2.0'
 * :ghissue:`55`: b'set up dual travis tests for libpysal (pip and github)'
@@ -99,8 +149,7 @@ Issues (18):
 * :ghissue:`38`: b'fix for python 3'
 * :ghissue:`39`: b'first draft of sphinx gallery'
 
-
-v<1.1.1>, 2018-05-17
+# Version 1.1.1 (2018-05-17)
 
 This release is the first tagged release of giddy on Github.
 Starting from this release, giddy supports python 3.5 and 3.6 only.
@@ -121,7 +170,7 @@ We closed a total of 20 issues, 8 pull requests and 12 regular issues;
 this is the full list (generated with the script 
 :file:`tools/github_stats.py`):
 
-Pull Requests (8):
+## Pull Requests (8):
 
 * :ghpull:`36`: b'add changelog for the release 1.1.0'
 * :ghpull:`35`: b'prepare for release'
@@ -132,7 +181,7 @@ Pull Requests (8):
 * :ghpull:`25`: b'[WIP] prepare for full metapackage integration'
 * :ghpull:`27`: b'api module for giddy'
 
-Issues (12):
+## Issues (12):
 
 * :ghissue:`36`: b'add changelog for the release 1.1.0'
 * :ghissue:`35`: b'prepare for release'

--- a/giddy/__init__.py
+++ b/giddy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 # __version__ has to be defined in the first line
 
 """

--- a/tools/gitcount.ipynb
+++ b/tools/gitcount.ipynb
@@ -26,8 +26,8 @@
    "outputs": [],
    "source": [
     "package_name = 'giddy'\n",
-    "release_date = '2018-08-26'\n",
-    "start_date = '2018-07-27'"
+    "release_date = '2019-04-08'\n",
+    "start_date = '2018-08-26'"
    ]
   },
   {
@@ -101,7 +101,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2018, 7, 27, 0, 0)"
+       "datetime.datetime(2018, 8, 26, 0, 0)"
       ]
      },
      "execution_count": 5,
@@ -155,7 +155,7 @@
     {
      "data": {
       "text/plain": [
-       "14"
+       "45"
       ]
      },
      "execution_count": 8,
@@ -254,7 +254,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['Wei Kang', 'Stefanie Lumnitz'])"
+       "dict_keys(['Wei Kang', 'James Gaboardi', 'Serge Rey'])"
       ]
      },
      "execution_count": 14,
@@ -434,15 +434,22 @@
     {
      "data": {
       "text/plain": [
-       "['remove giddy.api in README.rst (#66)',\n",
-       " ' chore: update for libpysal lower case module name changes (#65)',\n",
-       " 'replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)',\n",
-       " 'Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)',\n",
-       " 'version giddy only in giddy/__ini__.py (#60)',\n",
-       " 'remove duplicate makefile for sphinx build (#59)',\n",
-       " 'add zenodo doi badge to README (#58)',\n",
-       " 'add changelog for the release 1.2.0 (#57)',\n",
-       " 'prepare for release 1.2.0 (#56)']"
+       "['Add splot as a soft dependency for giddy  (#84)',\n",
+       " 'explicitly specifying Miniconda3 in .travis.yml (#83)',\n",
+       " 'configure doctest and coverage testing (#81)',\n",
+       " 'remove plot directive and indents (#80)',\n",
+       " 'fix missing reference labels in rendered docs  (#79)',\n",
+       " '(ENH) Full rank and geographic rank Markov methods (#73)',\n",
+       " '(BUG) update directional notebook to accommodate changes in libpysal (#78)',\n",
+       " '(BUG) fix notebooks (#76)',\n",
+       " 'remove redundant installation in travis.yml (#75)',\n",
+       " 'add pypi badge to README (#74)',\n",
+       " '(BUG) remove libpysal.api in Rank notebook (#72)',\n",
+       " 'update required versions of dependencies (#71)',\n",
+       " 'Update issue templates (#70)',\n",
+       " 'conform to PEP8 style guide (#69)',\n",
+       " 'update README with new doi and doc website (#68)',\n",
+       " 'REL: 2.0.0 (#67)']"
       ]
      },
      "execution_count": 20,
@@ -480,7 +487,7 @@
     {
      "data": {
       "text/plain": [
-       "'We closed a total of 20 issues (enhancements and bug fixes) through 9 pull requests, since our last release on 2018-07-27.'"
+       "'We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.'"
       ]
      },
      "execution_count": 23,
@@ -510,7 +517,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 20 issues (enhancements and bug fixes) through 9 pull requests, since our last release on 2018-07-27.\n",
+      "We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.\n",
       "\n",
       "## Issues Closed\n",
       "\n"
@@ -543,31 +550,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 20 issues (enhancements and bug fixes) through 9 pull requests, since our last release on 2018-07-27.\n",
+      "We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.\n",
       "\n",
       "## Issues Closed\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - remove api.py (#62)\n",
-      "  - set up travis dual testing against mapclassify and  esda (#63)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n",
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - .travis built on archaic Miniconda (#82)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - reference labels are missing from rendered docs (#77)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - Singular matrix when computing ergodic values (#32)\n",
+      "  - build notebooks for documentation (#6)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n",
       "\n",
       "## Pull Requests\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n"
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n"
      ]
     }
    ],
@@ -594,7 +617,8 @@
      "output_type": "stream",
      "text": [
       "  - Wei Kang\n",
-      "  - Stefanie Lumnitz\n"
+      "  - James Gaboardi\n",
+      "  - Serge Rey\n"
      ]
     }
    ],
@@ -620,36 +644,53 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 20 issues (enhancements and bug fixes) through 9 pull requests, since our last release on 2018-07-27.\n",
+      "We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.\n",
       "\n",
       "## Issues Closed\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - remove api.py (#62)\n",
-      "  - set up travis dual testing against mapclassify and  esda (#63)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n",
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - .travis built on archaic Miniconda (#82)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - reference labels are missing from rendered docs (#77)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - Singular matrix when computing ergodic values (#32)\n",
+      "  - build notebooks for documentation (#6)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n",
       "\n",
       "## Pull Requests\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n",
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n",
       "\n",
       "The following individuals contributed to this release:\n",
       "\n",
       "  - Wei Kang\n",
-      "  - Stefanie Lumnitz\n"
+      "  - James Gaboardi\n",
+      "  - Serge Rey\n"
      ]
     }
    ],
@@ -677,38 +718,55 @@
      "text": [
       "# Changes\n",
       "\n",
-      "Version 2.0.0 (2018-08-26)\n",
+      "Version 2.1.0 (2019-04-08)\n",
       "\n",
-      "We closed a total of 20 issues (enhancements and bug fixes) through 9 pull requests, since our last release on 2018-07-27.\n",
+      "We closed a total of 36 issues (enhancements and bug fixes) through 16 pull requests, since our last release on 2018-08-26.\n",
       "\n",
       "## Issues Closed\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - remove api.py (#62)\n",
-      "  - set up travis dual testing against mapclassify and  esda (#63)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n",
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - .travis built on archaic Miniconda (#82)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - reference labels are missing from rendered docs (#77)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - Singular matrix when computing ergodic values (#32)\n",
+      "  - build notebooks for documentation (#6)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n",
       "\n",
       "## Pull Requests\n",
-      "  - remove giddy.api in README.rst (#66)\n",
-      "  -  chore: update for libpysal lower case module name changes (#65)\n",
-      "  - replace `libpysal.api` imports with new imports in `markov.py` and `d… (#61)\n",
-      "  - Remove api.py and account for changes in (incoming) API of mapclassify, esda, and libpysal (#64)\n",
-      "  - version giddy only in giddy/__ini__.py (#60)\n",
-      "  - remove duplicate makefile for sphinx build (#59)\n",
-      "  - add zenodo doi badge to README (#58)\n",
-      "  - add changelog for the release 1.2.0 (#57)\n",
-      "  - prepare for release 1.2.0 (#56)\n",
+      "  - Add splot as a soft dependency for giddy  (#84)\n",
+      "  - explicitly specifying Miniconda3 in .travis.yml (#83)\n",
+      "  - configure doctest and coverage testing (#81)\n",
+      "  - remove plot directive and indents (#80)\n",
+      "  - fix missing reference labels in rendered docs  (#79)\n",
+      "  - (ENH) Full rank and geographic rank Markov methods (#73)\n",
+      "  - (BUG) update directional notebook to accommodate changes in libpysal (#78)\n",
+      "  - (BUG) fix notebooks (#76)\n",
+      "  - remove redundant installation in travis.yml (#75)\n",
+      "  - add pypi badge to README (#74)\n",
+      "  - (BUG) remove libpysal.api in Rank notebook (#72)\n",
+      "  - update required versions of dependencies (#71)\n",
+      "  - Update issue templates (#70)\n",
+      "  - conform to PEP8 style guide (#69)\n",
+      "  - update README with new doi and doc website (#68)\n",
+      "  - REL: 2.0.0 (#67)\n",
       "\n",
       "The following individuals contributed to this release:\n",
       "\n",
       "  - Wei Kang\n",
-      "  - Stefanie Lumnitz\n"
+      "  - James Gaboardi\n",
+      "  - Serge Rey\n"
      ]
     }
    ],
@@ -765,7 +823,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is to prepare for a new release 2.1.0 which integrates functionalities of two rank-based Markov classes proposed in [S. J. Rey. Rank-based Markov chains for regional income distribution dynamics. Journal of Geographical Systems, 16(2):115–137, 2014.](https://link.springer.com/article/10.1007/s10109-013-0189-0)
