### PR TITLE
migrate from readthedocs configuration file v1 to v2

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -76,3 +76,8 @@
     color: #222222;
     font-size: 100%;
 }
+
+div.body {
+    max-width: 1080px;
+}
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,19 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
 python:
-    version: 3.5
-    setup_py_install: true
-    pip_install: true
-    extra_requirements:
-        - tests
-        - docs
+    version: 3.7
+    install:
+        - requirements: requirements.txt
+        - method: pip
+          path: .
+          extra_requirements:
+              - tests
+              - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all


### PR DESCRIPTION
The current readthedocs configuration file for giddy and all the other pysal submodules is v1. As suggested on [the readthedocs docs page](https://docs.readthedocs.io/en/stable/config-file/v1.html), version 1 should not be used and I think this is the reason why the giddy docs building failed today https://readthedocs.org/projects/giddy/builds/9054523/

I've tested the updated configuration file (v2) on my fork and the building is successful https://readthedocs.org/projects/giddy-wei/builds/9054554/. 