### PR TITLE
(docs) change the css to accommodate new versions of sphinx and sphinx bootstrap theme 

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -72,10 +72,10 @@
 .bodycontainer { max-height: 600px; width: 100%; margin: 0; overflow-y: auto; }
 .table-scrollable { margin: 0; padding: 0; }
 
-.label {
-    color: #222222;
-    font-size: 100%;
-}
+/*.label {*/
+/*    color: #222222;*/
+/*    font-size: 100%;*/
+/*}*/
 
 div.body {
     max-width: 1080px;


### PR DESCRIPTION
references not looking good on  Sphinx 2.1.1:
![image](https://user-images.githubusercontent.com/7359284/59737357-2f2c2680-9212-11e9-9cef-f5ce2860edea.png)
After merging the PR, we should expect to see:
![image](https://user-images.githubusercontent.com/7359284/59737394-584cb700-9212-11e9-81be-a6361c8f29e1.png)
