### PR TITLE
(bug) debug travis-ci 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,17 @@ before_install:
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
+  - conda config --add channels conda-forge --force
+  - conda config --set channel_priority strict
+  - conda config --set safety_checks disabled
+  - conda create --name test-env python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements_tests.txt
   - source activate test-env
 
 install:
   - conda install --yes pip
-  - pip install -r requirements.txt
-  - pip install -r requirements_tests.txt
+#  - pip install -r requirements.txt
+#  - pip install -r requirements_tests.txt
+  #assuming pypi and conda-forge are hosting the same release
   - if "$PYSAL_PYPI"; then
         echo 'testing pypi libpysal esda mapclassify splot';
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - conda config --add channels conda-forge --force
   - conda config --set channel_priority strict
   - conda config --set safety_checks disabled
-  - conda create --name test-env python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements_tests.txt
+  - conda create -y --name test-env python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements_tests.txt
   - source activate test-env
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-numpy>=1.13.3
-scipy>=1.3.0
+scipy
 libpysal>=4.0.1
 mapclassify>=2.1.1
 esda>=2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy
+scipy>=1.3.0
 libpysal>=4.0.1
 mapclassify>=2.1.1
 esda>=2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=1.13.3
 scipy>=1.3.0
 libpysal>=4.0.1
 mapclassify>=2.1.1


### PR DESCRIPTION
this PR is to debug travis-ci testing https://travis-ci.org/pysal/giddy

rely on conda-forge instead of pypi for dependency installation (this assumes that conda-forge and pypi are hosting the same release)