### PR TITLE
remove the parameter in plt.show() due to the API change in Matplotlib (deprecation)

### DIFF
--- a/giddy/directional.py
+++ b/giddy/directional.py
@@ -92,6 +92,7 @@ class Rose(object):
 
         >>> import libpysal
         >>> from giddy.directional import Rose
+        >>> import numpy as np
         >>> import matplotlib.pyplot as plt
         >>> file_path = libpysal.examples.get_path("spi_download.csv")
         >>> f=open(file_path,'r')
@@ -206,7 +207,7 @@ class Rose(object):
         rose diagram conditional on the starting relative income:
 
         >>> fig1, _ = r8.plot(attribute=Y[:,0])
-        >>> plt.show(fig1)
+        >>> plt.show()
         """
 
         self.Y = Y


### PR DESCRIPTION
[The interactive example in the docstring of `Rose`](https://github.com/pysal/giddy/blob/master/giddy/directional.py#L209) plots the rose diagram by calling  function `plt.show(fig1)` from Matplotlib, resulting in the following warning:
```python
(base) weis-imac:giddy weikang$ nosetests --with-doctest 
./Users/weikang/Google Drive/python_repos/pysal-refactor/giddy/giddy/directional.py:1: MatplotlibDeprecationWarning: Passing the block parameter of show() positionally is deprecated since Matplotlib 3.1; the parameter will become keyword-only in 3.3.
```
The PR removes the parameter in the function (it is not quite needed) to avoid the warning and potential error once Matplotlib 3.3 is released.