### PR TITLE
add requirements on quantecon (>=0.4.7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ scipy>=1.3.0
 libpysal>=4.0.1
 mapclassify>=2.1.1
 esda>=2.1.1
-quantecon
+quantecon>=0.4.7


### PR DESCRIPTION
related to the incompatibility between the newer version of `numba` (0.49.1) and older version of `quantecon` (0.4.5)

https://github.com/pysal/pysal/issues/1177