### PR TITLE
Prepare for a formal release of giddy v2.3.1 with GitHub actions

### DIFF
--- a/giddy/__init__.py
+++ b/giddy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.1rc6"
+__version__ = "2.3.1"
 # __version__ has to be defined in the first line
 
 """

--- a/tools/gitcount.ipynb
+++ b/tools/gitcount.ipynb
@@ -525,7 +525,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "head = \"#Version {version} ({release_date})\\n\\n\".format(version=__version__, release_date=release_date)"
+    "head = \"# Version {version} ({release_date})\\n\\n\".format(version=__version__, release_date=release_date)"
    ]
   },
   {
@@ -534,8 +534,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_content = head+message+\"\\n\"\n",
-    "print(new_content)"
+    "# new_content = head+message+\"\\n\"\n",
+    "# print(new_content)"
    ]
   },
   {
@@ -544,11 +544,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#insert the new changes in the begining of CHANGELOG.md \n",
-    "with open(\"../CHANGELOG.md\", 'r+') as file:\n",
-    "    content = file.read()\n",
-    "    file.seek(0, 0)\n",
-    "    file.write(new_content+ content)"
+    "# #insert the new changes in the begining of CHANGELOG.md \n",
+    "# with open(\"../CHANGELOG.md\", 'r+') as file:\n",
+    "#     content = file.read()\n",
+    "#     file.seek(0, 0)\n",
+    "#     file.write(new_content+ content)"
    ]
   },
   {


### PR DESCRIPTION
Having tested the GitHub workflow [release_and_publish.yml](https://github.com/pysal/giddy/blob/master/.github/workflows/release_and_publish.yml), we are now ready to use it for a formal release (giddy v2.3.1).