### PR TITLE
(bug) pytest-runner is deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ def setup_package():
           maintainer_email='weikang9009@gmail.com',
           py_modules=['giddy'],
           python_requires='>3.5',
-          setup_requires=["pytest-runner"],
-          tests_require=["pytest"],
+          # setup_requires=["pytest-runner"],
+          # tests_require=["pytest"],
           keywords='spatial statistics, spatiotemporal analysis',
           classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
`pytest-runner` is deprecated as displayed on [its pypi project page](https://pypi.org/project/pytest-runner/5.2/). And:

>It is recommended that you:
> Remove ‘pytest-runner’ from your ‘setup_requires’, preferably removing the setup_requires option.
> Remove ‘pytest’ and any other testing requirements from ‘tests_require’, preferably removing the setup_requires option.

[The good integration practices with `pytest`](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner) no longer include the configuration of the two parameters  ‘setup_requires’ and ‘tests_require’.

`giddy` has also been running into [issues on conda-forge feedstock testing](https://github.com/conda-forge/giddy-feedstock/pull/8/checks), and I suspect `pytest-runner` could be the one to blame.

> 2020-06-10T03:39:09.2504682Z     ERROR: Could not find a version that satisfies the requirement pytest-runner (from versions: none)
> 2020-06-10T03:39:09.2512797Z     ERROR: No matching distribution found for pytest-runner
