### PR TITLE
version bump to v2.3.3

### DIFF
--- a/giddy/__init__.py
+++ b/giddy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 # __version__ has to be defined in the first line
 
 """


### PR DESCRIPTION
version bump to v2.3.3 due to broken [conda-forge feedstock testing](https://github.com/conda-forge/giddy-feedstock/pull/8/checks)