### PR TITLE
(docs) remove redirection to readthedocs as the docs are now hosted on github page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<body>
-    <meta charset="utf-8">
-    <title>Redirecting to https://giddy.readthedocs.io/</title>
-    <meta http-equiv="refresh" content="0; URL=https://giddy.readthedocs.io/">
-    <link rel="canonical" href="https://giddy.readthedocs.io/">
-</body>
-</html>


### PR DESCRIPTION
Remove redirection to readthedocs as the docs are now hosted on github page http://pysal.org/giddy/