### PR TITLE
add custom codecov schema

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  notify:
+    after_n_builds: 16
+coverage:
+  range: 50..95
+  round: nearest
+  precision: 1
+  status:
+    project:
+      default:
+        threshold: 2%
+    patch:
+      default:
+        threshold: 2%
+        target: 80%
+  ignore:
+    - "tests/*"
+comment:
+  layout: "reach, diff, files"
+  behavior: once
+  after_n_builds: 16
+  require_changes: true


### PR DESCRIPTION
This PR adds a custom `codecov` schema based on that of [`spaghetti`](https://github.com/pysal/spaghetti/blob/main/codecov.yml). The main advantage of a custom schema is that a coverage report will not be posted to the PR until *n* builds are complete (*n*=16 in this case).