### PR TITLE
(doc) explaining methods to break ties for spatial markov

### DIFF
--- a/giddy/markov.py
+++ b/giddy/markov.py
@@ -740,7 +740,14 @@ class Spatial_Markov:
 
     (4) `Spatial_Markov` also accepts discrete time series and calculates
     categorical spatial lags on which several transition probability matrices
-    are conditioned.
+    are conditioned. The categorical spatial lag is defined as the most common
+    categories of neighboring observations, weighted by their weight strengths.
+
+    Please note that occasionally there are ties for the "most common categories"
+    in the calculation of the categorical spatial lag. To break the tie, the
+    category of the focal observation is included with its neighbors. If this
+    does not resolve the tie, a winner is chosen randomly.
+
     Let's still use the US state income time series to demonstrate. We first
     discretize them into categories and then pass them to `Spatial_Markov`.
 


### PR DESCRIPTION
this PR is to add docstrings to explain the method that is used for breaking ties in the calculation of categorical spatial lag in spatial Markov

related to https://github.com/pysal/giddy/issues/215 and https://github.com/pysal/giddy/issues/216