### PR TITLE
change .toml file to anticipate the deprecation of old crand scheme in esda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "esda>=2.5",
+    "esda>=2.5, <2.9",
     "libpysal>=4.8",
     "mapclassify>=2.7",
     "quantecon>=0.8",


### PR DESCRIPTION
addressing https://github.com/pysal/giddy/issues/241