### PR TITLE
DEP: remove upper pin on esda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "esda>=2.7",
+    "esda>=2.7, <3",
     "libpysal>=4.12",
     "mapclassify>=2.7",
     "quantecon>=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "esda>=2.7, <2.9",
+    "esda>=2.7",
     "libpysal>=4.12",
     "mapclassify>=2.7",
     "quantecon>=0.8",


### PR DESCRIPTION
Any idea why does this exist? Locally, all tests run against esda main. It is breaking my local dev environment :D. I have a vague memory of seeing a reason somewhere but can't find it. I'd be keen to fix it if there is an actual issue.